### PR TITLE
Fix/edge cases

### DIFF
--- a/lib/components/sassParser.js
+++ b/lib/components/sassParser.js
@@ -10,6 +10,7 @@ const sass = require('node-sass');
 
 const _colorObj = {};
 let _mainSCSS = '';
+let _mainCharset = '';
 
 const _cssToSingleLine = contents => contents.replace(/^\s*\/\/.*/gm, '').replace(/\/\*.*\*\//g, '').replace(/(?:\r\n|\r|\n)/g, '');
 
@@ -196,8 +197,16 @@ const convertCssToObject = (cssContent) => {
   } catch (error) {
     msg('Error', 'The source CSS is not valid', colors.RED);
   }
-  const singleLineCss = _cssToSingleLine(plainCss);
+
+  let singleLineCss = _cssToSingleLine(plainCss);
+  const charsetRegexp = /^@charset\s\"([^\"]+)\";/;
+  const matches = charsetRegexp.exec(singleLineCss);
+  if (Array.isArray(matches) && matches[1]) {
+    _mainCharset = matches[1];
+    singleLineCss = singleLineCss.replace(charsetRegexp, '');
+  }
   dbg('singleLineCss', singleLineCss, colors.YELLOW);
+
   const cssArray = _cssToArray(singleLineCss);
   dbg('cssArray', cssArray, colors.PURPLE);
   try {
@@ -213,8 +222,9 @@ const convertCssToObject = (cssContent) => {
 const convertCssToScss = (cssContent) => {
   const cssObject = convertCssToObject(cssContent);
   _cssObjectToCss(cssObject);
+  const charset = _mainCharset ? `@charset "${_mainCharset}";\n`: "";
   const colorVars = _objToKeyValueCss(_colorObj);
-  const completedProcessing = colorVars + _mainSCSS;
+  const completedProcessing = charset + colorVars + _mainSCSS;
   const cleanResult = perfectionist.process(completedProcessing, { indentSize: 2, colorShorthand: false });
   return cleanResult.css;
 };

--- a/lib/components/sassParser.js
+++ b/lib/components/sassParser.js
@@ -220,7 +220,7 @@ const convertCssToObject = (cssContent) => {
 
 
 const convertCssToScss = (cssContent) => {
-  _mainSCSS = '', _mainCharset = '';
+  _mainSCSS = '', _mainCharset = '', _colorObj = {};
   const cssObject = convertCssToObject(cssContent);
   _cssObjectToCss(cssObject);
   const charset = _mainCharset ? `@charset "${_mainCharset}";\n`: "";

--- a/lib/components/sassParser.js
+++ b/lib/components/sassParser.js
@@ -93,17 +93,21 @@ const _cssarrayToObject = (fileContentsArr) => {
     const tail = value.match(/{(.*)}/)[1];
     dbg('Tail: ', tail, colors.BLUE);
 
-    const dividedHead = head.split(',');
+    let cleanHead = head.trim();
+    let dividedHead = undefined;
+    if (cleanHead.substr(0, 1) === '@') {
+      dividedHead = [cleanHead];
+    } else {
+      dividedHead = cleanHead.split(',');
+    }
 
     dividedHead.forEach((headvalue) => {
       if (head.length > 0) {
-        const cleanHeadValue = headvalue.trim();
-
-        let processedHead = _processCssHead(cleanHeadValue);
+        let processedHead = _processCssHead(headvalue);
         let processedBody = '';
 
         if (processedHead.substr(0, 2) === '"@') {
-          processedHead = `"${cleanHeadValue}"`;
+          processedHead = `"${headvalue}"`;
           processedBody = JSON.stringify(_cssarrayToObject(_cssToArray(tail)));
           processedBody = processedBody.substr(1, processedBody.length - 2);
         } else {

--- a/lib/components/sassParser.js
+++ b/lib/components/sassParser.js
@@ -21,7 +21,7 @@ const _processCssHead = (headContent) => {
     parsedHeadContent = trimmedHead
       .replace(/\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$/g, '')
       .replace(/"/g, '\\"')
-      .replace(/([^\s])(\.)([^\s])/g, '$1{&$2$3')
+      .replace(/([^\s\(])(\.)([^\s])/g, '$1{&$2$3')
       .replace(/(\s*::\s*)(?=([^\(]*\([^\(\)]*\))*[^\)]*$)/g, '{&:')
       .replace(/([^&])\s*:\s*(?=([^\(]*\([^\(\)]*\))*[^\)]*$)/g, '$1{&:')
       .replace(/(\s*>\s*)/g, '{>')

--- a/lib/components/sassParser.js
+++ b/lib/components/sassParser.js
@@ -220,6 +220,7 @@ const convertCssToObject = (cssContent) => {
 
 
 const convertCssToScss = (cssContent) => {
+  _mainSCSS = '', _mainCharset = '';
   const cssObject = convertCssToObject(cssContent);
   _cssObjectToCss(cssObject);
   const charset = _mainCharset ? `@charset "${_mainCharset}";\n`: "";

--- a/lib/components/sassParser.js
+++ b/lib/components/sassParser.js
@@ -35,7 +35,7 @@ const _processCssHead = (headContent) => {
 
 
 const _processCssBody = (bodyContent) => {
-  const bodyContentArr = bodyContent.replace(/(\s*;\s*)(?=([^\(]*\([^\(\)]*\))*[^\)]*$)/g, '~').split('~');
+  const bodyContentArr = bodyContent.replace(/(\s*;(?![a-zA-Z\d]+)\s*)(?=([^\(]*\([^\(\)]*\))*[^\)]*$)/g, '~').split('~');
   dbg('bodyContentArr', bodyContentArr, colors.CYAN);
   let cumulator = '';
 


### PR DESCRIPTION
This pull request fixes some edge cases that throw errors during conversion : 

Theses cases should be now fixed :
- `backgroup-url(data:[<mimetype>][;charset=<charset>][;base64],<encoded data>)`
- `@media (max-resolution: 140dpi), (-webkit-max-device-pixel-ratio: 1)`\
- `.event:not(.spanned) .title`
- `content: '•';`
- Unexpected contatenations when processing in a loop