### PR TITLE
Switch to Dart Sass as LibSass and Node Sass are deprecated.

### DIFF
--- a/lib/components/sassParser.js
+++ b/lib/components/sassParser.js
@@ -6,7 +6,7 @@ const {
 const _ = require('lodash');
 const perfectionist = require('perfectionist');
 const namer = require('color-namer');
-const sass = require('node-sass');
+const sass = require('sass');
 
 let _colorObj = {};
 let _mainSCSS = '';

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "color-namer": "^1.3.0",
     "devbug": "^0.1.3",
     "lodash": "^4.17.10",
-    "node-sass": "^4.9.0",
+    "sass": "^1.45.0",
     "perfectionist": "^2.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Switch to Dart Sass as LibSass and Node Sass are deprecated.